### PR TITLE
MNT: Update install_requires, package_data, version

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,0 @@
-include LFSpy\tests\matlab_Data.mat

--- a/README.md
+++ b/README.md
@@ -21,6 +21,9 @@ LFS requires:
 ### Testing
 We recommend running the provided test after installing LFSpy to ensure the results obtained match expected outputs.
 
+`pytest` may be installed either directly through pip (`pip install pytest`) or using the `test`
+extra (`pip install LFSpy[test]`).
+
 ```bash
 pytest --pyargs LFSpy
 ```

--- a/setup.py
+++ b/setup.py
@@ -5,18 +5,24 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="LFSpy",
-    version="1.0.1",
+    version="1.0.2-dev",
     author="Oliver Cook, Kiret Dhindsa, Areeb Khawaja, Ron Harwood, Thomas Mudway",
-    install_requires=['numpy>=1.14', 'scipy>=1.1', 'scikit-learn>=0.18.2', 'pytest>=5.0.0'],
+    install_requires=['numpy>=1.14', 'scipy>=1.1', 'scikit-learn>=0.18.2'],
     long_description=long_description,
     long_description_content_type="text/markdown",
     url="https://github.com/McMasterRS/LFS/",
     packages=setuptools.find_packages(),
-    include_package_data=True,
+    package_data={
+        'LFSpy': ['matlab_Data.mat'],
+        },
     classifiers=[
         "Programming Language :: Python :: 3",
         "License :: OSI Approved :: BSD License",
         "Operating System :: OS Independent",
     ],
+    tests_require=['pytest>=5.0.0'],
     python_requires='>=3.6',
-)   
+    extras_require={
+        'test': ['pytest>=5.0.0']
+        }
+)

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setuptools.setup(
     url="https://github.com/McMasterRS/LFS/",
     packages=setuptools.find_packages(),
     package_data={
-        'LFSpy': ['matlab_Data.mat'],
+        'LFSpy': ['tests/matlab_Data.mat'],
         },
     classifiers=[
         "Programming Language :: Python :: 3",


### PR DESCRIPTION
This PR makes a couple changes to the `setup.py` configuration:

1) Move `pytest` out of `install_requires` and into `extras_require` and `tests_require`. This is common practice in Python, to allow people to have minimal dependencies while also giving a straightforward path to testing. `tests_require` is used when `python setup.py test` is called, which is pretty rare these days.

2) Replace `MANIFEST.in` and `include_package_data=True` with `package_data`. This is just intended to keep configuration centralized.